### PR TITLE
:technologist: add GitHub Action to move linked issues to review

### DIFF
--- a/.github/workflows/updateIssueStatus.yml
+++ b/.github/workflows/updateIssueStatus.yml
@@ -1,0 +1,87 @@
+name: Move Linked Issue to Review in GitHub Project
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  update_project_status:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      projectV2: write
+
+    steps:
+      - name: Extract linked issue number from PR body
+        id: extract
+        run: |
+          ISSUE_NUMBER=$(echo "${{ github.event.pull_request.body }}" | grep -oE '#[0-9]+' | tr -d '#' | head -n1)
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo "No linked issue found in PR body."
+            exit 0
+          fi
+          echo "issue_number=$ISSUE_NUMBER" >> $GITHUB_OUTPUT
+
+      - name: Get Issue ID and Project Item ID
+        id: ids
+        uses: octokit/graphql-action@v2.x
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          query: |
+            query($owner: String!, $repo: String!, $issueNumber: Int!, $projectId: ID!) {
+              repository(owner: $owner, name: $repo) {
+                issue(number: $issueNumber) {
+                  id
+                }
+              }
+              projectV2(id: $projectId) {
+                items(first: 100) {
+                  nodes {
+                    id
+                    content {
+                      ... on Issue {
+                        id
+                        number
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          variables: |
+            {
+              "owner": "${{ github.repository_owner }}",
+              "repo": "${{ github.event.repository.name }}",
+              "issueNumber": ${{ steps.extract.outputs.issue_number }},
+              "projectId": "PVT_kwDODFbjbM4A_0Hm"
+            }
+
+      - name: Extract matching item ID
+        id: match
+        run: |
+          ISSUE_ID=$(echo '${{ steps.ids.outputs.data }}' | jq -r '.repository.issue.id')
+          ITEM_ID=$(echo '${{ steps.ids.outputs.data }}' | jq -r '.projectV2.items.nodes[] | select(.content.id == "'"$ISSUE_ID"'") | .id')
+          echo "issue_id=$ISSUE_ID" >> $GITHUB_OUTPUT
+          echo "item_id=$ITEM_ID" >> $GITHUB_OUTPUT
+
+      - name: Update status to "Review"
+        uses: octokit/graphql-action@v2.x
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          query: |
+            mutation {
+              updateProjectV2ItemFieldValue(input: {
+                projectId: "PVT_kwDODFbjbM4A_0Hm",
+                itemId: "${{ steps.match.outputs.item_id }}",
+                fieldId: "PVTSSF_lADODFbjbM4A_0HmzgyzjnI",
+                value: {
+                  singleSelectOptionId: "5ef0dc97"
+                }
+              }) {
+                projectV2Item {
+                  id
+                }
+              }
+            }


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate moving linked issues to the "Review" status in the GitHub Project when a pull request is opened. The workflow extracts the linked issue from the PR body, finds the corresponding project item, and updates its status.

**Automation for project management:**

* Added `.github/workflows/updateIssueStatus.yml` workflow to automatically move a linked issue to the "Review" status in the GitHub Project when a pull request referencing the issue is opened. The workflow parses the PR body for an issue number, retrieves the issue and project item IDs, and updates the project's status field using the GitHub GraphQL API.
Closes: #9 