### PR TITLE
:technologist: fix permission scope for project updates in GitHub Action

### DIFF
--- a/.github/workflows/updateIssueStatus.yml
+++ b/.github/workflows/updateIssueStatus.yml
@@ -11,7 +11,7 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
-      projectV2: write
+      projects: write
 
     steps:
       - name: Extract linked issue number from PR body


### PR DESCRIPTION
Fixes #11